### PR TITLE
Fix lilypond paths and compile score routines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.pd_linux
 *.dll
 .vscode/
+tests/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for notes
 
 # specify a location for Pd if desired
-# PDDIR = /home/yourname/somedirectory/pd-0.49-0
+PDDIR = ../pure-data
 
 lib.name = notesLib
 

--- a/include/notes_lib.h
+++ b/include/notes_lib.h
@@ -47,7 +47,10 @@ void find_arpeggio(int a, FILE *f);
 void find_notehead(int a, FILE *f);
 int readbarfile(int a[][8], FILE *f);
 void copyfiles(FILE *f, FILE *g);
-void compile_score(char *buf, char *name, int debug, int SLAVE, int render);
+// score compiling and opening routines
+int compile(char *buf, char *name, int debug);
+void open_pdf(char *buf);
+int compile_and_open(char *buf, char *name, int debug, int SLAVE, int render, int open);
 
 // setup routines
 void mainscore_setup();

--- a/include/notes_lib.h
+++ b/include/notes_lib.h
@@ -3,10 +3,10 @@
 // developed by Jaime Oliver La Rosa (la.rosa@nyu.edu)
 // @ the NYU Waverly Labs in the Music Department - FAS. (nyu-waverlylabs.org)
 // updated by Fede Camara Halac (fch226@nyu.edu)
-// Released under the GNU General Public License. 
+// Released under the GNU General Public License.
 
 #include "m_pd.h"
-#include "g_canvas.h" 
+#include "g_canvas.h"
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -15,10 +15,10 @@
 #define MXS 2048 // Maximum size of arrays  ( or input messages...)
 
 #if  defined(__APPLE__) || defined(unix)
-#define UNIX 1 
-#else 
+#define UNIX 1
+#else
 // We need this for getline() to work on windows. TODO: remove this dependency.
-#include "getline.h" 
+#include "getline.h"
 #endif
 
 // The following are the definitions for the Lilypond path in different platforms. Used in the compile() function in notes_lib.c
@@ -27,11 +27,11 @@
 // assume the lilypond is in Applications...
 #define LYDIR "/Applications/LilyPond.app"
 #define LYBINDIR "/Contents/Resources/bin/"
-
-#elif defined _WIN32
-// assume lilypond is in Program Files (x86)...
-#define LYDIR "C:\\Program Files (x86)\\LilyPond"
-#define LYBINDIR "\\usr\\bin\\"
+//
+// #elif defined _WIN32
+// // assume lilypond is in Program Files (x86)...
+// #define LYDIR "C:\Program Files (x86)\LilyPond"
+// #define LYBINDIR "\\usr\\bin\\"
 
 #else // Do not define LY paths for other platforms.
 // assume the lilypond command exists in the Path
@@ -74,5 +74,3 @@ int compile_and_open(char *buf, char *name, int debug, int SLAVE, int render, in
 void mainscore_setup();
 void line2score_setup();
 void notes_setup();
-
-

--- a/include/notes_lib.h
+++ b/include/notes_lib.h
@@ -21,6 +21,24 @@
 #include "getline.h" 
 #endif
 
+// The following are the definitions for the Lilypond path in different platforms. Used in the compile() function in notes_lib.c
+// The LYDIR path is the default value for lily_dir, settable from pd.
+#ifdef __APPLE__
+// assume the lilypond is in Applications...
+#define LYDIR "/Applications/LilyPond.app"
+#define LYBINDIR "/Contents/Resources/bin/"
+
+#elif defined _WIN32
+// assume lilypond is in Program Files (x86)...
+#define LYDIR "C:\\Program Files (x86)\\LilyPond"
+#define LYBINDIR "\\usr\\bin\\"
+
+#else // Do not define LY paths for other platforms.
+// assume the lilypond command exists in the Path
+#define LYDIR ""
+#define LYBINDIR ""
+#endif
+
 // these are defined in m_pd.h for file handling across platforms
 #define fopen sys_fopen
 #define fclose sys_fclose
@@ -48,9 +66,9 @@ void find_notehead(int a, FILE *f);
 int readbarfile(int a[][8], FILE *f);
 void copyfiles(FILE *f, FILE *g);
 // score compiling and opening routines
-int compile(char *buf, char *name, int debug);
+int compile(char *buf, char *name, int debug, char *lily_dir);
 void open_pdf(char *buf);
-int compile_and_open(char *buf, char *name, int debug, int SLAVE, int render, int open);
+int compile_and_open(char *buf, char *name, int debug, int SLAVE, int render, int open, char *lily_dir);
 
 // setup routines
 void mainscore_setup();

--- a/src/mainscore.c
+++ b/src/mainscore.c
@@ -125,7 +125,7 @@ void mainscore_write(t_mainscore *x, t_symbol *s)								{
 	strcat( scorename, ".ly");
 	fp1 = fopen(scorename, "w");
 	if(!fp1)						{
-		error("%s: couldn't create", buf);
+		pd_error(x,"%s: couldn't create", buf);
 		return;
 	}
 //// _______________________________________________ WRITE SCORE	
@@ -209,7 +209,7 @@ void mainscore_write(t_mainscore *x, t_symbol *s)								{
 		fclose(fp1);
 		post("mainscore: .ly score finished");
     // compile and open
-    if(!compile_and_open(buf, scorename, x->debug, 0, 1, x->open)){
+    if(compile_and_open(buf, scorename, x->debug, 0, 1, x->open,LYBINDIR)){
       pd_error(x, "notes: error compiling score");
     }
     }  // if a file is correctly provided.

--- a/src/mainscore.c
+++ b/src/mainscore.c
@@ -20,6 +20,7 @@ typedef struct mainscore 														{
   const char *dummysym; // const to remove warning
   int ii, debug, auth_n, titl_n, sub_title_n;
   int inst_n, papersize, paperorientation, part_i, i_part_i, voice, total_voices;
+  int open;
 } 
 t_mainscore;
 ////	____________________________________________________ INPUT
@@ -208,7 +209,9 @@ void mainscore_write(t_mainscore *x, t_symbol *s)								{
 		fclose(fp1);
 		post("mainscore: .ly score finished");
     // compile and open
-    compile_score(buf, scorename, x->debug, 0, 1);
+    if(!compile_and_open(buf, scorename, x->debug, 0, 1, x->open)){
+      pd_error(x, "notes: error compiling score");
+    }
     }  // if a file is correctly provided.
 	//*/
 }
@@ -217,6 +220,19 @@ void mainscore_clear(t_mainscore *x)											{
 	x->part_i = x->i_part_i = 0;
     x->auth_n = x->titl_n = x->sub_title_n = 0; 
 	post("mainscore: Cleared");
+}
+////	____________________________________________________ OPENING SWITCH
+void mainscore_open(t_mainscore *x, t_floatarg f) 							{
+	int i;
+	if (f == 0) {
+		i = 0;
+		post("mainscore: score opening off");
+	}
+	else {
+		i = 1;
+		post("mainscore: score opening on");
+	}
+	x->open = i;
 }
 ////	____________________________________________________ DEBUG  
 void mainscore_debug(t_mainscore *x, t_floatarg f) 								{	
@@ -281,6 +297,7 @@ void *mainscore_new(t_floatarg ff)												{
 	x->paperorientation 	= 0;
 	x->part_i = x->part_i	= 0;
 	x->total_voices			= (int) ff;
+  x->open = 1;
     return (void *)x;
 }
 void mainscore_setup(void)														{
@@ -295,6 +312,7 @@ void mainscore_setup(void)														{
 	class_addmethod(mainscore_class, (t_method)mainscore_clear, 	gensym("clear"), 				0);
 	class_addmethod(mainscore_class, (t_method)mainscore_debug, 	gensym("debug"), 	A_DEFFLOAT, 0);
 	class_addmethod(mainscore_class, (t_method)mainscore_paper, 	gensym("paper"), 	A_DEFFLOAT, A_DEFFLOAT, 0);
+  class_addmethod(mainscore_class, (t_method)mainscore_open, 	gensym("open"), 	A_DEFFLOAT, 0);
   class_sethelpsymbol(mainscore_class, gensym("notes"));
 	// post("mainscore:\ttesting version: 2015-03-26");
 }

--- a/src/notes.c
+++ b/src/notes.c
@@ -52,7 +52,7 @@ typedef struct notes 													{
   char title[64][130], sub_title[64][130], author[64][130], osname[130], lily_dir[MAXPDSTRING], barfile[MAXPDSTRING], inst[150];
   const char *dummysym; // const to remove warning
   int ii, refdur, debug, auth_n, titl_n, sub_title_n, tempo, OS, lastpit_ch, lastpit;
-  int SLAVE, inst_n, papersize, paperorientation, render;
+  int SLAVE, inst_n, papersize, paperorientation, render, open;
 }
 t_notes;
 
@@ -2402,7 +2402,9 @@ void notes_write(t_notes *x, t_symbol *s)								{
 
     }
     // compile and open
-    compile_score(buf, scorename, x->debug, x->SLAVE, x->render);
+    if(compile_and_open(buf, scorename, x->debug, x->SLAVE, x->render, x->open)){
+      pd_error(x, "notes: error compiling score");
+    }
 	} // if a file is correctly provided.
 	else 									{
 		post("notes: ERROR: Can't flush because no input has been provided... you have to enter some notes!");
@@ -2440,6 +2442,19 @@ void notes_render(t_notes *x, t_floatarg f) 							{
 		post("notes: score rendering on");
 	}
 	x->render = i;
+}
+////	____________________________________________________ OPENING SWITCH
+void notes_open(t_notes *x, t_floatarg f) 							{
+	int i;
+	if (f == 0) {
+		i = 0;
+		post("notes: score opening off");
+	}
+	else {
+		i = 1;
+		post("notes: score opening on");
+	}
+	x->open = i;
 }
 ////	____________________________________________________ DEBUG
 void notes_debug(t_notes *x, t_floatarg f) 								{
@@ -2517,6 +2532,7 @@ void *notes_new(t_floatarg ff)												{
     x->inst_n = x->tempo = x->auth_n = x->titl_n = 0;
     x->refdur 			= 32;
     x->render 			= 1;
+    x->open         = 1;
     x->papersize 		= 4;
 	x->paperorientation = 0;
   x->OS = -1; // -1 = undefined OS, 0 = Mac, 1 = Linux
@@ -2541,4 +2557,5 @@ void notes_setup(void)														{
 	class_addmethod(notes_class, (t_method)notes_render, 	gensym("render"), 	A_DEFFLOAT, 0);
 	class_addmethod(notes_class, (t_method)notes_debug, 	gensym("debug"), 	A_DEFFLOAT, 0);
 	class_addmethod(notes_class, (t_method)notes_paper, 	gensym("paper"), 	A_DEFFLOAT, A_DEFFLOAT, 0);
+	class_addmethod(notes_class, (t_method)notes_open, 	gensym("open"), 	A_DEFFLOAT, 0);
 }

--- a/src/notes.c
+++ b/src/notes.c
@@ -1063,7 +1063,7 @@ void notes_write(t_notes *x, t_symbol *s)								{
 			FILE *fp3;
 			fp3 = fopen( x->barfile, "r");
 			if(!fp3) {
-				error("%s: couldn't read barfile, send one to the second inlet", x->barfile);
+				pd_error(x, "%s: couldn't read barfile, send one to the second inlet", x->barfile);
 				return;
 			}
 			else 	ii = readbarfile(x->bar_info, (FILE *) fp3); //////sdsdfsdfsdfsdf
@@ -1225,7 +1225,7 @@ void notes_write(t_notes *x, t_symbol *s)								{
 			outlet_symbol(x->x_outlet1, masterbar);
 			fp = fopen(bar_buf, "w");
 			if(!fp)	{
-				error("%s: couldn't create", bar_buf);
+				pd_error(x, "%s: couldn't create", bar_buf);
 				return;
 			}
 			else {
@@ -1648,7 +1648,7 @@ void notes_write(t_notes *x, t_symbol *s)								{
 		strcat( scorename, ".ly");
 		fp1 = fopen(scorename, "w");
 		if(!fp1)						{
-			error("%s: couldn't create", buf);
+			pd_error(x, "%s: couldn't create", buf);
 			return;
 		}
 	//// _______________________________________________ WRITE SCORE
@@ -1687,7 +1687,7 @@ void notes_write(t_notes *x, t_symbol *s)								{
 			strcat( partname, "_part.ly");
 			fp2 = fopen(partname, "w");
 			if(!fp2)						{
-				error("%s: couldn't create", buf);
+				pd_error(x, "%s: couldn't create", buf);
 				return;
 			}
 			else {
@@ -2402,7 +2402,7 @@ void notes_write(t_notes *x, t_symbol *s)								{
 
     }
     // compile and open
-    if(compile_and_open(buf, scorename, x->debug, x->SLAVE, x->render, x->open)){
+    if(compile_and_open(buf,scorename,x->debug,x->SLAVE,x->render,x->open, x->lily_dir)){
       pd_error(x, "notes: error compiling score");
     }
 	} // if a file is correctly provided.
@@ -2501,7 +2501,7 @@ void notes_inst(t_notes *x, t_symbol *s) 		{
 void notes_lily_dir(t_notes *x, t_symbol *s, int argc, t_atom *argv) 	{
 	int i; i = argc; i++;
 	x->dummysym = s->s_name;
-	atom_string(argv, x->lily_dir, 1000);
+	atom_string(argv, x->lily_dir, MAXPDSTRING);
 	post("notes: Lilypond directory set to: %s", x->lily_dir);
 }
 ////	____________________________________________________ READFILE
@@ -2534,15 +2534,15 @@ void *notes_new(t_floatarg ff)												{
     x->render 			= 1;
     x->open         = 1;
     x->papersize 		= 4;
-	x->paperorientation = 0;
-  x->OS = -1; // -1 = undefined OS, 0 = Mac, 1 = Linux
-	strcpy( x->lily_dir, "~/bin");
-    strcpy (x->inst, "inst");
+	  x->paperorientation = 0;
+  
+	  strcpy(x->lily_dir, LYDIR); // see notes_lib.h
+    strcpy(x->inst, "inst");
     return (void *)x;
 }
 void notes_setup(void)														{
-    notes_class = 	class_new(gensym("notes"), (t_newmethod)notes_new, 0, sizeof(t_notes), 0, A_DEFFLOAT, 0);
-
+    notes_class = class_new(gensym("notes"), (t_newmethod)notes_new, 0, sizeof(t_notes), 0, A_DEFFLOAT, 0);
+  
 	class_addmethod(notes_class, (t_method)notes_input, 	gensym("input"), 	A_GIMME, 	0);
 	class_addmethod(notes_class, (t_method)notes_write, 	gensym("write"), 	A_SYMBOL,	0);
 	class_addmethod(notes_class, (t_method)notes_title, 	gensym("title"), 	A_GIMME, 	0);

--- a/src/notes_lib.c
+++ b/src/notes_lib.c
@@ -470,21 +470,22 @@ void copyfiles(FILE *f, FILE *g)			{
 	}
 } // f1 into f2 
 
-int compile(char *buf, char *name, int debug) {
+int compile(char *buf, char *name, int debug, char *lily_dir) {
     char cmdbuf[MAXPDSTRING];
-    post("notes: compiling score");
-    // assume the lilypond command exists in the Path
-    snprintf(cmdbuf, MAXPDSTRING, "lilypond -o %s %s", buf, name);
+    if (debug >= 1) post("notes: compiling score");
+
+    snprintf(cmdbuf, MAXPDSTRING, "%s%slilypond -o %s %s", lily_dir, LYBINDIR, buf, name);
+
     cmdbuf[MAXPDSTRING-1] = 0;
     if (debug >= 1) post("notes: cmdbuf = %s", cmdbuf);
     // RENDER THE SCORE TO PDF
     if (!system(cmdbuf)) {    
-      post("notes: score compiled");
+      if (debug >= 1) post("notes: score compiled");
       return 0;
     } else {
       post("notes: score did not compile");
-      post("... you might want to run the following command manually:");
-      post("%s", cmdbuf);
+      post("... you might want to run the following command manually:\n");
+      post("%s\n", cmdbuf);
       return 1;
     }
 }
@@ -498,21 +499,21 @@ void open_pdf(char *buf) {
     sys_gui(cmdbuf);
 }
 
-int compile_and_open(char *buf, char *name, int debug, int SLAVE, int render, int OPEN) {
+int compile_and_open(char *buf, char *name, int debug, int SLAVE, int render, int OPEN, char *lily_dir) {
     if (!render) {
       if (debug >= 1) post("notes: skipping score rendering");
     } else if (SLAVE == 1) {
       if (debug >= 1) post("notes: render disabled in slave mode");
     } else { // SLAVE == 0 && render == 1
       if (!system(NULL)) {
-        post("notes: system() not found");
+        if (debug >= 1) post("notes: system() not found");
         return 1;
       } else {
-        if(compile(buf, name, debug))  {
-          post("notes: score did not compile");
-          return 1;
+        if(!compile(buf, name, debug, lily_dir))  {
+            if (OPEN) open_pdf(buf);
          } else {
-           if (OPEN) open_pdf(buf);
+            if (debug >= 1) post("notes: score did not compile");
+            return 1;
          }
       }
     }


### PR DESCRIPTION
`lily_dir`: 
The biggest change here is the `lily_dir` default value. _Following lilypond.org instructions on macOS creates problems_ if running Pd by double-clicking instead of from the terminal app (#3). Because of this, the `system()` function did not get the right path to `~/bin` where the suggested lilypond shell script resides. A solution for this is to simply bypass lilypond.org’s instructions and use the lilypond binary directly from within notes_lib. 

On macOS:
There are two macros, `LYDIR` which points to `“/Applications/Lilypond.app”` and `LYBINDIR` which points to `“/Contents/Resources/bin/”` where the `lilypond` binary resides. The former is simply a default value, and has to be reset (every time) if Lilypond.app is in another place. The way to set this is with the `lily_dir` message, as in `“lily_dir /another/path/to/Lilypond.app”`

The benefit here is that the mac user does not need to have `lilypond` in the path: only the Lilypond.app needs to reside in Applications, which is the default anyways, and notes takes care of the rest. 

On other platforms, lilypond must be on the `PATH`. On linux, this should not be asking too much. On Windows, the steps on lilypond.org are exactly what you need to do, and there is no need to open a terminal. 


More notes: 

This PR splits the compile and open function with two other subroutines `compile` and `open_pdf`, dedicated exclusively to render pdf scores and open the rendered pdf file, respectively. This way, there is a clearer error reporting on each step. 

There is also a `compile_and_open` routine calling the two mentioned subroutines in order, which is used by `mainscore` and `notes`. 

An “open 1|0” message was added to both objects to disable / enable (default) opening the pdf score. This is useful to run automated tests. 

Tests reside locally, and are ignored for now, but should be useful to publish eventually with the code. 

Fixes #3 